### PR TITLE
Updated to use scutil for compatibility with OSX versions >= 10.11

### DIFF
--- a/autovpn.applescript
+++ b/autovpn.applescript
@@ -2,22 +2,19 @@ on idle
 	try
 		do shell script "ping -o www.apple.com"
 		tell application "System Events"
-			tell current location of network preferences
-				set _fsta to (POSIX file ("/opt/devel/etc/vpn.status"))
-				set _vsta to first item of (read _fsta using delimiter linefeed)
-				if _vsta is equal to "start" then
-					set _fdef to (POSIX file ("/opt/devel/etc/vpn.default"))
-					set _vdef to first item of (read _fdef using delimiter linefeed)
-					if _vdef is not equal to "" then
-						set _vpn to the service _vdef
-						if _vpn is not null then
-							if current configuration of _vpn is not connected then
-								connect _vpn
-							end if
-						end if
+			set _fsta to (POSIX file ("/opt/devel/etc/vpn.status"))
+			set _vsta to first item of (read _fsta using delimiter linefeed)
+			if _vsta is equal to "start" then
+				set _fdef to (POSIX file ("/opt/devel/etc/vpn.default"))
+				set _vdef to first item of (read _fdef using delimiter linefeed)
+				if _vdef is not equal to "" then
+					set _vpn to _vdef
+					set rc to do shell script "scutil --nc status " & _vpn
+					if rc starts with "Disconnected" then
+						do shell script "scutil --nc start " & _vpn
 					end if
 				end if
-			end tell
+			end if
 			return 10
 		end tell
 	on error


### PR DESCRIPTION
Based on http://stackoverflow.com/questions/32957121/in-mac-os-x-10-11-opening-a-vpn-connection-window-with-the-command-line-gives-m
